### PR TITLE
feat: adopt the plugin api

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ You have already seen the `audiences` option in the examples above, but here is 
 runEager.call(pluginContext, {
   // Overrides the base path if the plugin was installed in a sub-directory
   basePath: '',
+  // Lets you configure if we are in a prod environment or not
+  // (prod environments do not get the pill overlay)
+  isProdHost: () => window.location.hostname.endsWith('hlx.page')
+    || window.location.hostname === ('localhost')
 
   /* Generic properties */
   // RUM sampling rate on regular AEM pages is 1 out of 100 page views

--- a/README.md
+++ b/README.md
@@ -26,15 +26,14 @@ git subtree pull --squash --prefix plugins/experience-decisioning git@github.com
 
 If you prefer using `https` links you'd replace `git@github.com:adobe/aem-experience-decisioning.git` in the above commands by `https://github.com/adobe/aem-experience-decisioning.git`.
 
-## Prerequisites
-
-The AEM Experience Decisioning plugin requires 
 ## Project instrumentation
 
 ### On top of the plugin system
 
 The easiest way to add the plugin is if your project is set up with the plugin system extension in the boilerplate.
 You'll know you have it if `window.hlx.plugins` is defined on your page.
+
+If you don't have it, you can follow the proposal in https://github.com/adobe/aem-lib/pull/23 and apply the changes to your `aem.js`/`lib-franklin.js`.
 
 Once you have confirmed this, you'll need to edit your `scripts.js` in your AEM project and add the following at the start of the file:
 ```js

--- a/README.md
+++ b/README.md
@@ -26,7 +26,34 @@ git subtree pull --squash --prefix plugins/experience-decisioning git@github.com
 
 If you prefer using `https` links you'd replace `git@github.com:adobe/aem-experience-decisioning.git` in the above commands by `https://github.com/adobe/aem-experience-decisioning.git`.
 
+## Prerequisites
+
+The AEM Experience Decisioning plugin requires 
 ## Project instrumentation
+
+### On top of the plugin system
+
+The easiest way to add the plugin is if your project is set up with the plugin system extension in the boilerplate.
+You'll know you have it if `window.hlx.plugins` is defined on your page.
+
+Once you have confirmed this, you'll need to edit your `scripts.js` in your AEM project and add the following at the start of the file:
+```js
+const AUDIENCES = {
+  mobile: () => window.innerWidth < 600,
+  desktop: () => window.innerWidth >= 600,
+  // define your custom audiences here as needed
+};
+
+window.hlx.plugins.add('experience-decisioning', {
+  condition: () => getMetadata('experiment')
+    || Object.keys(getAllMetadata('campaign')).length
+    || Object.keys(getAllMetadata('audience')).length,
+  options: { audiences: AUDIENCES },
+  url: '/plugins/experience-decisioning/src/index.js',
+});
+```
+
+### Without the plugin system
 
 To properly connect and configure the plugin for your project, you'll need to edit your `scripts.js` in your AEM project and add the following:
 
@@ -77,7 +104,7 @@ To properly connect and configure the plugin for your project, you'll need to ed
         || Object.keys(getAllMetadata('audience')).length) {
         // eslint-disable-next-line import/no-relative-packages
         const { loadEager: runEager } = await import('../plugins/experience-decisioning/src/index.js');
-        await runEager.call(pluginContext, { audiences: AUDIENCES });
+        await runEager(document, { audiences: AUDIENCES }, pluginContext);
       }
       …
     }
@@ -90,11 +117,10 @@ To properly connect and configure the plugin for your project, you'll need to ed
       // Add below snippet at the end of the lazy phase
       if ((getMetadata('experiment')
         || Object.keys(getAllMetadata('campaign')).length
-        || Object.keys(getAllMetadata('audience')).length)
-        && (window.location.hostname.endsWith('hlx.page') || window.location.hostname === ('localhost'))) {
+        || Object.keys(getAllMetadata('audience')).length)) {
         // eslint-disable-next-line import/no-relative-packages
         const { loadLazy: runLazy } = await import('../plugins/experience-decisioning/src/index.js');
-        await runLazy.call(pluginContext, { audiences: AUDIENCES });
+        await runLazy(document, { audiences: AUDIENCES }, pluginContext);
       }
     }
     ```
@@ -111,7 +137,7 @@ runEager.call(pluginContext, {
   basePath: '',
   // Lets you configure if we are in a prod environment or not
   // (prod environments do not get the pill overlay)
-  isProdHost: () => window.location.hostname.endsWith('hlx.page')
+  isProd: () => window.location.hostname.endsWith('hlx.page')
     || window.location.hostname === ('localhost')
 
   /* Generic properties */

--- a/src/index.js
+++ b/src/index.js
@@ -654,7 +654,11 @@ export async function loadLazy(document, options, context) {
     ...DEFAULT_OPTIONS,
     ...(options || {}),
   };
-  // eslint-disable-next-line import/no-cycle
-  const preview = await import('./preview.js');
-  preview.default(document, pluginOptions, { ...context, getResolvedAudiences });
+  if (window.location.hostname.endsWith('hlx.page')
+    || window.location.hostname === ('localhost')
+    || (options.isProdHost && !options.isProdHost())) {
+    // eslint-disable-next-line import/no-cycle
+    const preview = await import('./preview.js');
+    preview.default(document, pluginOptions, { ...context, getResolvedAudiences });
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ async function replaceInner(path, element) {
     const resp = await fetch(plainPath);
     if (!resp.ok) {
       // eslint-disable-next-line no-console
-      console.log('error loading experiment content:', resp);
+      console.log('error loading content:', resp);
       return false;
     }
     const html = await resp.text();
@@ -95,7 +95,7 @@ async function replaceInner(path, element) {
     return true;
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.log(`error loading experiment content: ${plainPath}`, e);
+    console.log(`error loading content: ${plainPath}`, e);
   }
   return false;
 }
@@ -463,14 +463,12 @@ export async function runCampaign(document, options, context) {
   }
 
   let audiences = context.getMetadata(`${pluginOptions.campaignsMetaTagPrefix}-audience`);
-  if (!audiences) {
-    return false;
-  }
-
-  audiences = audiences.split(',').map(context.toClassName);
-  const resolvedAudiences = await getResolvedAudiences(audiences, pluginOptions, context);
-  if (!!resolvedAudiences && !resolvedAudiences.length) {
-    return false;
+  if (audiences) {
+    audiences = audiences.split(',').map(context.toClassName);
+    const resolvedAudiences = await getResolvedAudiences(audiences, pluginOptions, context);
+    if (!!resolvedAudiences && !resolvedAudiences.length) {
+      return false;
+    }
   }
 
   const allowedCampaigns = context.getAllMetadata(pluginOptions.campaignsMetaTagPrefix);

--- a/src/index.js
+++ b/src/index.js
@@ -356,8 +356,7 @@ export async function getConfig(experiment, instantExperiment, pluginOptions, co
     ? context.toClassName(usp.get(pluginOptions.audiencesQueryParameter))
     : null;
 
-  experimentConfig.resolvedAudiences = await getResolvedAudiences.call(
-    this,
+  experimentConfig.resolvedAudiences = await getResolvedAudiences(
     experimentConfig.audiences,
     pluginOptions,
     context,
@@ -513,8 +512,7 @@ export async function serveAudience(document, options, context) {
     return false;
   }
 
-  const audiences = await getResolvedAudiences.call(
-    this,
+  const audiences = await getResolvedAudiences(
     Object.keys(configuredAudiences),
     pluginOptions,
     context,

--- a/src/index.js
+++ b/src/index.js
@@ -654,7 +654,7 @@ export async function loadLazy(document, options, context) {
   };
   if (window.location.hostname.endsWith('hlx.page')
     || window.location.hostname === ('localhost')
-    || (options.isProdHost && !options.isProdHost())) {
+    || (typeof options.isProd === 'function' && !options.isProd())) {
     // eslint-disable-next-line import/no-cycle
     const preview = await import('./preview.js');
     preview.default(document, pluginOptions, { ...context, getResolvedAudiences });

--- a/src/preview.js
+++ b/src/preview.js
@@ -276,11 +276,11 @@ function populatePerformanceMetrics(div, config, {
 async function decorateExperimentPill(overlay, options, context) {
   const config = window?.hlx?.experiment;
   const experiment = context.toClassName(context.getMetadata(options.experimentsMetaTag));
-  // eslint-disable-next-line no-console
-  console.log('preview experiment', experiment);
   if (!experiment || !config) {
     return;
   }
+  // eslint-disable-next-line no-console
+  console.log('preview experiment', experiment);
 
   const pill = createPopupButton(
     `Experiment: ${config.id}`,
@@ -339,7 +339,7 @@ async function decorateCampaignPill(overlay, options, context) {
   const forcedAudience = usp.has(options.audiencesQueryParameter)
     ? context.toClassName(usp.get(options.audiencesQueryParameter))
     : null;
-  const audiences = campaigns.audience.split(',').map(context.toClassName);
+  const audiences = campaigns.audience?.split(',').map(context.toClassName) || [];
   const resolvedAudiences = await context.getResolvedAudiences(audiences, options);
   const isActive = forcedAudience
     ? audiences.includes(forcedAudience)

--- a/src/preview.js
+++ b/src/preview.js
@@ -273,9 +273,9 @@ function populatePerformanceMetrics(div, config, {
  * Create Badge if a Page is enlisted in a AEM Experiment
  * @return {Object} returns a badge or empty string
  */
-async function decorateExperimentPill(overlay, options) {
+async function decorateExperimentPill(overlay, options, context) {
   const config = window?.hlx?.experiment;
-  const experiment = this.toClassName(this.getMetadata(options.experimentsMetaTag));
+  const experiment = context.toClassName(context.getMetadata(options.experimentsMetaTag));
   // eslint-disable-next-line no-console
   console.log('preview experiment', experiment);
   if (!experiment || !config) {
@@ -300,7 +300,7 @@ async function decorateExperimentPill(overlay, options) {
     },
     config.variantNames.map((vname) => createVariant(experiment, vname, config, options)),
   );
-  pill.classList.add(`is-${this.toClassName(config.status)}`);
+  pill.classList.add(`is-${context.toClassName(config.status)}`);
   overlay.append(pill);
 
   const performanceMetrics = await fetchRumData(experiment, options);
@@ -329,25 +329,25 @@ function createCampaign(campaign, isSelected, options) {
  * Create Badge if a Page is enlisted in a AEM Campaign
  * @return {Object} returns a badge or empty string
  */
-async function decorateCampaignPill(overlay, options) {
-  const campaigns = this.getAllMetadata(options.campaignsMetaTagPrefix);
+async function decorateCampaignPill(overlay, options, context) {
+  const campaigns = context.getAllMetadata(options.campaignsMetaTagPrefix);
   if (!Object.keys(campaigns).length) {
     return;
   }
 
   const usp = new URLSearchParams(window.location.search);
   const forcedAudience = usp.has(options.audiencesQueryParameter)
-    ? this.toClassName(usp.get(options.audiencesQueryParameter))
+    ? context.toClassName(usp.get(options.audiencesQueryParameter))
     : null;
-  const audiences = campaigns.audience.split(',').map(this.toClassName);
-  const resolvedAudiences = await this.getResolvedAudiences(audiences, options);
+  const audiences = campaigns.audience.split(',').map(context.toClassName);
+  const resolvedAudiences = await context.getResolvedAudiences(audiences, options);
   const isActive = forcedAudience
     ? audiences.includes(forcedAudience)
     : (!resolvedAudiences || !!resolvedAudiences.length);
   const campaign = (usp.has(options.campaignsQueryParameter)
-    ? this.toClassName(usp.get(options.campaignsQueryParameter))
+    ? context.toClassName(usp.get(options.campaignsQueryParameter))
     : null)
-    || (usp.has('utm_campaign') ? this.toClassName(usp.get('utm_campaign')) : null);
+    || (usp.has('utm_campaign') ? context.toClassName(usp.get('utm_campaign')) : null);
   const pill = createPopupButton(
     `Campaign: ${campaign || 'default'}`,
     {
@@ -363,7 +363,7 @@ async function decorateCampaignPill(overlay, options) {
       createCampaign('default', !campaign || !isActive, options),
       ...Object.keys(campaigns)
         .filter((c) => c !== 'audience')
-        .map((c) => createCampaign(c, isActive && this.toClassName(campaign) === c, options)),
+        .map((c) => createCampaign(c, isActive && context.toClassName(campaign) === c, options)),
     ],
   );
 
@@ -388,15 +388,15 @@ function createAudience(audience, isSelected, options) {
  * Create Badge if a Page is enlisted in a AEM Audiences
  * @return {Object} returns a badge or empty string
  */
-async function decorateAudiencesPill(overlay, options) {
-  const audiences = this.getAllMetadata(options.audiencesMetaTagPrefix);
+async function decorateAudiencesPill(overlay, options, context) {
+  const audiences = context.getAllMetadata(options.audiencesMetaTagPrefix);
   if (!Object.keys(audiences).length || !Object.keys(options.audiences).length) {
     return;
   }
 
   const usp = new URLSearchParams(window.location.search);
   const forcedAudience = usp.has(options.audiencesQueryParameter)
-    ? this.toClassName(usp.get(options.audiencesQueryParameter))
+    ? context.toClassName(usp.get(options.audiencesQueryParameter))
     : null;
   const pill = createPopupButton(
     'Audiences',
@@ -421,13 +421,13 @@ async function decorateAudiencesPill(overlay, options) {
  * Decorates Preview mode badges and overlays
  * @return {Object} returns a badge or empty string
  */
-export default async function decoratePreviewMode(options) {
+export default async function decoratePreviewMode(document, options, context) {
   try {
-    this.loadCSS(`${options.basePath || window.hlx.codeBasePath}/plugins/experience-decisioning/src/preview.css`);
+    context.loadCSS(`${options.basePath || window.hlx.codeBasePath}/plugins/experience-decisioning/src/preview.css`);
     const overlay = getOverlay(options);
-    await decorateAudiencesPill.call(this, overlay, options);
-    await decorateCampaignPill.call(this, overlay, options);
-    await decorateExperimentPill.call(this, overlay, options);
+    await decorateAudiencesPill(overlay, options, context);
+    await decorateCampaignPill(overlay, options, context);
+    await decorateExperimentPill(overlay, options, context);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log(e);

--- a/src/preview.js
+++ b/src/preview.js
@@ -394,24 +394,25 @@ async function decorateAudiencesPill(overlay, options, context) {
     return;
   }
 
-  const usp = new URLSearchParams(window.location.search);
-  const forcedAudience = usp.has(options.audiencesQueryParameter)
-    ? context.toClassName(usp.get(options.audiencesQueryParameter))
-    : null;
+  const resolvedAudiences = await context.getResolvedAudiences(
+    Object.keys(audiences),
+    options,
+    context,
+  );
   const pill = createPopupButton(
     'Audiences',
     {
       label: 'Audiences for this page:',
     },
     [
-      createAudience('default', !forcedAudience || forcedAudience === 'default', options),
+      createAudience('default', !resolvedAudiences.length || resolvedAudiences[0] === 'default', options),
       ...Object.keys(audiences)
         .filter((a) => a !== 'audience')
-        .map((a) => createAudience(a, forcedAudience === a, options)),
+        .map((a) => createAudience(a, resolvedAudiences && resolvedAudiences[0] === a, options)),
     ],
   );
 
-  if (forcedAudience) {
+  if (resolvedAudiences.length) {
     pill.classList.add('is-active');
   }
   overlay.append(pill);


### PR DESCRIPTION
Refactor the engine to adopt the new plugin system proposal in https://github.com/adobe/aem-boilerplate/pull/254.

BREAKING:
- The new plugin API changes the high-level signature of the exported methods. All methods now follow a `*(document, options, context)` signature, and do not pass a `this` context anymore

Test URLs:
- https://main--aem-experience-decisioning-demo--ramboz.hlx.page/audiences/
- https://main--aem-experience-decisioning-demo--ramboz.hlx.page/campaigns/
- https://main--aem-experience-decisioning-demo--ramboz.hlx.page/experiments/